### PR TITLE
Fix misaligned selection regions & indent guide gaps

### DIFF
--- a/styles/amu-extra.less
+++ b/styles/amu-extra.less
@@ -49,10 +49,8 @@ atom-text-editor.is-focused .selection .region,
     &:after {
         content: '';
         position: absolute;
-        top: -2px;
         left: -2px;
         right: -2px;
-        bottom: -2px;
         border: 2px solid @syntax-selection-color;
         border-radius: 3px;
     }


### PR DESCRIPTION
The fancy selection region borders cause two minor issues. First, they sometimes make gaps appear in the indent guides in selected regions. Second, they lead to a slight misalignment between the selection region in the gutter and the selection region in the main editor when selecting multiple lines. This fixed both issues.

Before:
<img width="1053" alt="before" src="https://cloud.githubusercontent.com/assets/11735900/14011835/d62d9096-f1a1-11e5-940c-e85c3497f33d.png">

After:
<img width="1046" alt="after" src="https://cloud.githubusercontent.com/assets/11735900/14011842/e3bb8be6-f1a1-11e5-863f-9d8c68cb5ee5.png">