### PR TITLE
Use border-color instead of color for cursor

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -47,7 +47,7 @@ atom-text-editor {
     }
 
     .cursor {
-        color: @syntax-cursor-color;
+        border-color: @syntax-cursor-color;
         border-width: 2px;
     }
 


### PR DESCRIPTION
The current theme does not set the cursor correctly as it sets `color` instead of `border-color`.