### PR TITLE
Fix JSON string soft wrap highlighting

### DIFF
--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,39 +1,23 @@
 .syntax--json {
-    .syntax--meta {
-        &.syntax--array.syntax--structure .syntax--string.syntax--quoted.syntax--double {
-            color: @green;
-
-            > * {
-                color: currentColor;
-
-                &.syntax--punctuation {
-                    &.syntax--begin, &.syntax--end {
-                        color: @cyan;
-                    }
-                }
-            }
-        }
-
-        .syntax--punctuation.syntax--separator.syntax--key-value + .syntax--string.syntax--quoted {
-            color: @green;
-
-            * {
-                color: currentColor;
-
-                &.syntax--punctuation {
-                    &.syntax--begin, &.syntax--end {
-                        color: @cyan;
-                    }
-                }
-            }
-        }
-
-        &.syntax--structure.syntax--dictionary .syntax--string.syntax--quoted {
-            color: @purple;
-
-            .syntax--punctuation.syntax--string {
-                color: currentColor;
-            }
-        }
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
+        color: @purple;
+      }
+      color: @purple;
     }
+  }
+
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
+      color: @green;
+
+      &.syntax--punctuation {
+          &.syntax--begin, &.syntax--end {
+              color: @cyan;
+          }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Currently JSON syntax highlighting breaks for strings when soft wrap is turned on. This is issue https://github.com/atom-material/atom-material-syntax/issues/42. A commenter remarked that One Dark doesn't have this problem, so I toyed around with the One Dark theme's `json.less` file until I got it to match the Material Syntax colors.

I don't have much experience with CSS/less, so test it out before a merge, but it seems to work fine.

Current:

![image](https://user-images.githubusercontent.com/15164633/38578340-aba2d4b2-3cd1-11e8-9dd3-df37d30a92d8.png)

With this PR:
![image](https://user-images.githubusercontent.com/15164633/38578357-b93e1c80-3cd1-11e8-8376-417f5857169f.png)

